### PR TITLE
docs: add link to Kubelet documentation in Cluster Architecture section

### DIFF
--- a/docs/02 - Core Concepts/01 - Cluster Architecture.md
+++ b/docs/02 - Core Concepts/01 - Cluster Architecture.md
@@ -8,7 +8,7 @@
 
 - [**Node**](/docs/02%20-%20Core%20Concepts/10-Nodes.md) : A node is a worker machine in Kubernetes, that takes care of the workload for a particular application(s). Each node is maintained by Controlplane and has components like Kubelet, Container Runtime Interface(CRI) and Kubeproxy. 
 
-- **Kubelet** : This is the primary "node agent" that runs on each node. The kubelet works in terms of PodSpec (a yaml or json object that describes a pod)
+- [**Kubelet**](/docs/02%20-%20Core%20Concepts/07-Kubelet.md) : This is the primary "node agent" that runs on each node. The kubelet works in terms of PodSpec (a yaml or json object that describes a pod)
 
 - **kube-proxy** : The kubernetes network proxy runs on each node. This reflects services as defined in the Kubernetes API on each node and can do simple TCP, UDP, and SCTP stream forwarding or round-robin TCP, UDP, and SCTP forwarding across a set of backends. Services can be of many flavors: ClusterIP and NodePort
 


### PR DESCRIPTION
fix #225 
close #224 